### PR TITLE
Regenerate blurhash when replacing single images

### DIFF
--- a/ImageBlurhash.module.php
+++ b/ImageBlurhash.module.php
@@ -153,6 +153,7 @@ class ImageBlurhash extends InputfieldImage implements Module
 
     public function insertBlurhash(string $blurhash, Page $page, Field $field, Pageimage $image)
     {
+        $image->filedata("blurhash-created", time());
         $image->filedata("blurhash", $blurhash);
         $page->save($field->name, ["quiet" => true, "noHooks" => true]);
         return true;

--- a/ImageBlurhash.module.php
+++ b/ImageBlurhash.module.php
@@ -67,7 +67,7 @@ class ImageBlurhash extends InputfieldImage implements Module
         $images = $page->get($field->name);
         if ($field->createBlurhash && $images->count() > 0 && !$page->hasStatus(Page::statusDeleted)) {
             $image = $images->last(); // get the last added images (should be the currently uploaded images)
-            if (!$this->getRawBlurhash($image)) {
+            if (!$this->getRawBlurhash($image, false)) {
                 if ($blurhash = $this->createBlurhash($image->filename)) {
                     $this->insertBlurhash($blurhash, $page, $field, $image);
                 }
@@ -75,10 +75,12 @@ class ImageBlurhash extends InputfieldImage implements Module
         }
     }
 
-    public function getRawBlurhash(Pageimage $image)
+    public function getRawBlurhash(Pageimage $image, $includeStale = true)
     {
+        $created = (int) $image->filedata("blurhash-created");
+        $current = $includeStale || ($created >= $image->modified);
         $blurhash = $image->filedata("blurhash");
-        if ($blurhash && !empty($blurhash)) {
+        if ($blurhash && !empty($blurhash) && $current) {
             return $blurhash;
         }
 


### PR DESCRIPTION
- Fix an issue where replacing an image in a single-file field would not regenerate the blurhash
- Solved by comparing blurhash creation timestamp to image modification timestamp before returning blurhash
- Only checked on save: existing blurhashes from previous versions stay valid